### PR TITLE
support for as low as 18 Teives, 3761

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -22,7 +22,7 @@ if (!function_exists('toSecular')) {
             throw new InvalidDateException("{$year} is not a leap year.");
         }
 
-        return Zman::parse(jdtogregorian(jewishtojd($month, $day, $year)));
+        return Zman::createFromFormat('m/d/Y', jdtogregorian(jewishtojd($month, $day, $year)))->startOfDay();
     }
 }
 

--- a/tests/InstantiationTest.php
+++ b/tests/InstantiationTest.php
@@ -46,5 +46,11 @@ class InstantiationTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Zman::class, $zman);
         $this->assertEquals('Feb 2, 2016', $zman->toFormattedDateString());
         $this->assertEquals('כ״ג שבט, תשע״ו', $zman->toFormattedJewishHebrewDateString());
+
+        $zman = Zman::createFromJewishDate(3761, 4, 18);
+
+        $this->assertInstanceOf(Zman::class, $zman);
+        $this->assertEquals('Jan 1, 0001', $zman->toFormattedDateString());
+        $this->assertEquals('י״ח טבת, תשס״א', $zman->toFormattedJewishHebrewDateString());
     }
 }


### PR DESCRIPTION
Resolves https://github.com/zman-org/zman/issues/37

This PR fixes support for the oldest date supported by `jdtojewish`/`jewishtojd` We should either figure out how to support older dates or throw an exception when the date is older